### PR TITLE
show the annotation highlight under the text

### DIFF
--- a/src/components/Annotation.tsx
+++ b/src/components/Annotation.tsx
@@ -27,14 +27,18 @@ function Annotaion({
   return (
     <>
       {position.rects.map((rect, i) => {
+        let opacity = 0.2;
+        if (isHighlighted) opacity = 0.4;
+        if (isSelected) opacity = 0.66;
+
         return (
           <div
             key={i}
             className={style.annotaion}
             style={{
               background: legend.color,
-              opacity: isSelected || isHighlighted ? 0.4 : 0.15,
-              borderBottom: isSelected ? '2px solid #000' : 'none',
+              opacity,
+              borderBottom: isSelected ? `2px solid #333` : 'none',
               transform: `translate(${rect.x}px,${rect.y}px)`,
               height: rect.height,
               width: rect.width,

--- a/src/styles/TextArea.module.css
+++ b/src/styles/TextArea.module.css
@@ -10,6 +10,9 @@
 
 .text_node_container {
   white-space: pre-wrap;
+  position: relative;
+  z-index: 5;
+  pointer-events: none;
 }
 
 .arrow {


### PR DESCRIPTION
show the annotation highlight under the text so that we can use darker color without worrying about cover the text

![Screen Shot 2019-10-03 at 9 58 36 AM](https://user-images.githubusercontent.com/902357/66133334-7ae9bc80-e5c4-11e9-9f99-4c76a0cdebe7.png)
