### PR TITLE
figure out map text selection back to original text position

### DIFF
--- a/src/components/AnnotationLabel.tsx
+++ b/src/components/AnnotationLabel.tsx
@@ -83,5 +83,3 @@ export default function AnnotationLabel({
     </div>
   );
 }
-
-//  AnnotationLabel;

--- a/src/lib/mock-config-data.ts
+++ b/src/lib/mock-config-data.ts
@@ -37,6 +37,16 @@ export const ontology: IOntology = {
       ],
     },
     {
+      entryName: 'forte.data.ontology.stanfordnlp_ontology.Foo',
+      parentEntryName: 'forte.data.ontology.top.Annotation',
+      attributes: [
+        {
+          attributeName: 'name',
+          attributeType: 'str',
+        },
+      ],
+    },
+    {
       entryName: 'forte.data.ontology.stanfordnlp_ontology.Document',
       parentEntryName: 'forte.data.ontology.top.Annotation',
     },

--- a/src/lib/mock-data-2.ts
+++ b/src/lib/mock-data-2.ts
@@ -1268,6 +1268,10 @@ export const singlePack: ISinglePack = {
         id: 'forte.data.ontology.base_ontology.Document',
         name: 'Document',
       },
+      {
+        id: 'forte.data.ontology.stanfordnlp_ontology.Foo',
+        name: 'Foo',
+      },
     ],
     links: [
       {

--- a/src/styles/TextArea.module.css
+++ b/src/styles/TextArea.module.css
@@ -13,6 +13,7 @@
   position: relative;
   z-index: 5;
   pointer-events: none;
+  line-height: 20px;
 }
 
 .annotation_line_toggle {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
@@ -17,9 +13,8 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react"
+    "jsx": "react",
+    "downlevelIteration": true
   },
-  "include": [
-    "src"
-  ]
+  "include": ["src"]
 }


### PR DESCRIPTION
Since the text is spread out, when selecting text, we need to map the selection position back to the original position in the text. Also spread white space should be excluded from the selection. The PR get that sorted out. 

![Oct-15-2019 17-15-17](https://user-images.githubusercontent.com/902357/66870431-71bb0100-ef6f-11e9-8a2c-d10f04ed4cc8.gif)
