### PR TITLE
implement annotation and link api route

### DIFF
--- a/simple-backend/nlpviewer_backend/handlers/document.py
+++ b/simple-backend/nlpviewer_backend/handlers/document.py
@@ -2,6 +2,7 @@ from django.contrib import admin
 from django.urls import include, path
 from django.http import HttpResponse, JsonResponse
 from django.forms import model_to_dict
+import uuid
 import json
 from ..models import Document, User
 from ..lib.require_login import require_login
@@ -58,16 +59,44 @@ def delete(request, document_id):
 
 @require_login
 def new_annotation(request, document_id):
-    received_json_data = json.loads(request.body)
 
     # get pack from db
     # generate a annotation id
     # add id to received annotation data
     # insert the annotation data into pack
-    # save to db
-    # return id
+    # - get text pack from dock
+    # - parse text pack to json
+    # - append annotatition to annotations in json
+    # - stringify the updated json and update the textPack in doc
+    # - save back to doc
 
-    return HttpResponse('OK')
+    # Example post data
+    # {
+    #     "py/object": "forte.data.ontology.base_ontology.EntityMention",
+    #     "py/state": {
+    #         "_span": {
+    #             "begin": 0,
+    #             "end": 8,
+    #             "py/object": "forte.data.base.Span"
+    #         },
+    #         "_tid": 1,
+    #         "ner_type": "DATE"
+    #     }
+    # }
+    received_json_data = json.loads(request.body)
+    doc = Document.objects.get(pk=document_id)
+
+    annotation_id = str(uuid.uuid1())
+    annotation = received_json_data.get('data')
+    annotation["py/state"]['_tid'] = annotation_id
+
+    docJson = model_to_dict(doc)
+    textPackJson = json.loads(docJson['textPack'])
+    textPackJson['py/state']['annotations'].append(annotation)
+    doc.textPack = json.dumps(textPackJson)
+    doc.save()
+
+    return JsonResponse({"id": received_json_data}, safe=False)
 
 
 @require_login
@@ -81,7 +110,22 @@ def edit_annotation(request, document_id, annotation_id):
     # save to db
     # return OK
 
+    received_json_data = json.loads(request.body)
+    doc = Document.objects.get(pk=document_id)
+    annotation = received_json_data.get('data')
+
+    docJson = model_to_dict(doc)
+    textPackJson = json.loads(docJson['textPack'])
+
+    for index, item in enumerate(textPackJson['py/state']['annotations']):
+        if item["py/state"]['_tid'] == annotation_id:
+            textPackJson['py/state']['annotations'][index] = annotation
+
+    doc.textPack = json.dumps(textPackJson)
+    doc.save()
+
     return HttpResponse('OK')
+    # return JsonResponse(model_to_dict(doc), safe=False)
 
 
 @require_login
@@ -92,12 +136,25 @@ def delete_annotation(request, document_id, annotation_id):
     # save to db
     # return OK
 
+    doc = Document.objects.get(pk=document_id)
+    docJson = model_to_dict(doc)
+    textPackJson = json.loads(docJson['textPack'])
+
+    deleteIndex = -1
+    for index, item in enumerate(textPackJson['py/state']['annotations']):
+        if item["py/state"]['_tid'] == annotation_id:
+            deleteIndex = index
+
+    del textPackJson['py/state']['annotations'][deleteIndex]
+    doc.textPack = json.dumps(textPackJson)
+    doc.save()
+
     return HttpResponse('OK')
+    # return JsonResponse(model_to_dict(doc), safe=False)
 
 
 @require_login
 def new_link(request, document_id):
-    received_json_data = json.loads(request.body)
 
     # get pack from db
     # generate a link id
@@ -106,29 +163,66 @@ def new_link(request, document_id):
     # save to db
     # return id
 
-    return HttpResponse('OK')
+    # example post data
+    # {
+    #     "py/object": "forte.data.ontology.base_ontology.PredicateLink",
+    #     "py/state": {
+    #       "_child": 5,
+    #       "_parent": 10,
+    #       "_tid": 34,
+    #       "arg_type": "ARG0"
+    #     }
+    #   }
 
-
-@require_login
-def edit_link(request, document_id, annotation_id):
     received_json_data = json.loads(request.body)
+    doc = Document.objects.get(pk=document_id)
 
-    # get pack from db
-    # find link from pack
-    # - return error if not found
-    # update link with received link data
-    # save to db
-    # return OK
+    link_id = str(uuid.uuid1())
+    link = received_json_data.get('data')
+    link["py/state"]['_tid'] = link_id
+
+    docJson = model_to_dict(doc)
+    textPackJson = json.loads(docJson['textPack'])
+    textPackJson['py/state']['links'].append(link)
+    doc.textPack = json.dumps(textPackJson)
+    doc.save()
+
+    return JsonResponse({"id": received_json_data}, safe=False)
+
+
+@require_login
+def edit_link(request, document_id, link_id):
+    received_json_data = json.loads(request.body)
+    doc = Document.objects.get(pk=document_id)
+    link = received_json_data.get('data')
+
+    docJson = model_to_dict(doc)
+    textPackJson = json.loads(docJson['textPack'])
+
+    for index, item in enumerate(textPackJson['py/state']['links']):
+        if item["py/state"]['_tid'] == link_id:
+            textPackJson['py/state']['links'][index] = link
+
+    doc.textPack = json.dumps(textPackJson)
+    doc.save()
 
     return HttpResponse('OK')
 
 
 @require_login
-def delete_link(request, document_id, annotation_id):
+def delete_link(request, document_id, link_id):
 
-    # get pack from db
-    # remove link with id from pack
-    # save to db
-    # return OK
+    doc = Document.objects.get(pk=document_id)
+    docJson = model_to_dict(doc)
+    textPackJson = json.loads(docJson['textPack'])
+
+    deleteIndex = -1
+    for index, item in enumerate(textPackJson['py/state']['links']):
+        if item["py/state"]['_tid'] == link_id:
+            deleteIndex = index
+
+    del textPackJson['py/state']['links'][deleteIndex]
+    doc.textPack = json.dumps(textPackJson)
+    doc.save()
 
     return HttpResponse('OK')

--- a/simple-backend/nlpviewer_backend/urls.py
+++ b/simple-backend/nlpviewer_backend/urls.py
@@ -33,21 +33,16 @@ urlpatterns = [
     path('documents/<int:document_id>/edit', document.edit),
     path('documents/<int:document_id>/delete', document.delete),
 
-    path('documents', document.listAll),
-    path('documents/new', document.create),
-    path('documents/<int:document_id>', document.query),
-    path('documents/<int:document_id>/edit', document.edit),
-    path('documents/<int:document_id>/delete', document.delete),
-
-    path('documents/:document_id/annotations/new', document.new_annotation),
-    path('documents/:document_id/annotations/:annotation_id/edit',
+    path('documents/<int:document_id>/annotations/new', document.new_annotation),
+    path('documents/<int:document_id>/annotations/<int:annotation_id>/edit',
          document.edit_annotation),
-    path('documents/:document_id/annotations/:annotation_id/delete',
+    path('documents/<int:document_id>/annotations/<int:annotation_id>/delete',
          document.delete_annotation),
 
-    path('documents/:document_id/link/new', document.new_link),
-    path('documents/:document_id/link/:link_id/edit', document.edit_link),
-    path('documents/:document_id/link/:link_id/delete', document.delete_link),
+    path('documents/<int:document_id>/link/new', document.new_link),
+    path('documents/<int:document_id>/link/<int:link_id>/edit', document.edit_link),
+    path('documents/<int:document_id>/link/<int:link_id>/delete',
+         document.delete_link),
 
     path('admin/', admin.site.urls),
 ]

--- a/src/app/lib/api.ts
+++ b/src/app/lib/api.ts
@@ -92,3 +92,7 @@ async function postData(url = '', data = {}) {
     return response;
   }
 }
+
+let w: any = window;
+
+w.postData = postData;


### PR DESCRIPTION
### Annotation and link route

- POST `/documents/:document_id/annotations/new`
  - params `{ data: string (json) }`
  - return `{ id: string }`
- POST `/documents/:document_id/annotations/:annotation_id/edit`
  - params `{ data: string (json) }`
  - return `OK`
- POST `/documents/:document_id/annotations/:annotation_id/delete`
  - return `OK`
- POST `/documents/:document_id/link/new`
  - params `{ data: string (json) }`
  - return `{ id: string }`
- POST `/documents/:document_id/link/:annotation_id/edit`
  - params `{ data: string (json) }`
  - return `OK`
- POST `/documents/:document_id/link/:annotation_id/delete`
  - return `OK`