### PR TITLE
next and prev

### DIFF
--- a/simple-backend/nlpviewer_backend/handlers/document.py
+++ b/simple-backend/nlpviewer_backend/handlers/document.py
@@ -289,7 +289,7 @@ def get_next_document_id(request, document_id):
         next_id = next_doc.id
     else:
         next_id = document_id
-    return JsonResponse({'id': next_id}, safe=False)
+    return JsonResponse({'id': str(next_id)}, safe=False)
 
 @require_login
 def get_prev_document_id(request, document_id):
@@ -297,9 +297,9 @@ def get_prev_document_id(request, document_id):
     doc = Document.objects.get(pk=document_id) 
     project = doc.project
     docs = project.documents
-    prev_doc = docs.filter(id__lt=document_id).first()
+    prev_doc = docs.filter(id__lt=document_id).last()
     if prev_doc:
         prev_id = prev_doc.id
     else:
         prev_id = document_id
-    return JsonResponse({'id': prev_id}, safe=False)
+    return JsonResponse({'id': str(prev_id)}, safe=False)

--- a/simple-backend/nlpviewer_backend/handlers/document.py
+++ b/simple-backend/nlpviewer_backend/handlers/document.py
@@ -277,3 +277,29 @@ def get_doc_ontology_pack(request, document_id):
     }
 
     return JsonResponse(docJson, safe=False)
+
+@require_login
+def get_next_document_id(request, document_id):
+
+    doc = Document.objects.get(pk=document_id) 
+    project = doc.project
+    docs = project.documents
+    next_doc = docs.filter(id__gt=document_id).first()
+    if next_doc:
+        next_id = next_doc.id
+    else:
+        next_id = document_id
+    return JsonResponse({'id': next_id}, safe=False)
+
+@require_login
+def get_prev_document_id(request, document_id):
+
+    doc = Document.objects.get(pk=document_id) 
+    project = doc.project
+    docs = project.documents
+    prev_doc = docs.filter(id__lt=document_id).first()
+    if prev_doc:
+        prev_id = prev_doc.id
+    else:
+        prev_id = document_id
+    return JsonResponse({'id': prev_id}, safe=False)

--- a/simple-backend/nlpviewer_backend/urls.py
+++ b/simple-backend/nlpviewer_backend/urls.py
@@ -46,7 +46,9 @@ urlpatterns = [
     path('documents/<int:document_id>/links/<int:link_id>/edit', document.edit_link),
     path('documents/<int:document_id>/links/<int:link_id>/delete',
          document.delete_link),
-
+    
+    path('next_doc/<int:document_id>', document.get_next_document_id),
+    path('prev_doc/<int:document_id>', document.get_prev_document_id),
 
     path('projects', project.listAll),
     path('projects/new', project.create),

--- a/src/app/lib/api.ts
+++ b/src/app/lib/api.ts
@@ -26,6 +26,14 @@ export function fetchDocOntology(id: string): Promise<APIDocOntology> {
   return fetch(`/api/ontology_from_doc/${id}`).then(r => r.json());
 }
 
+export function nextDocument(id: string): Promise<any> {
+  return fetch(`/api/next_doc/${id}`).then(r => r.json());
+}
+
+export function prevDocument(id: string): Promise<any> {
+  return fetch(`/api/prev_doc/${id}`).then(r => r.json());
+}
+
 export function updateDocument(id: string, name: string, textPack: string) {
   return postData(`/api/documents/${id}/edit`, {
     name: name,

--- a/src/nlpviewer/components/TextViewer.tsx
+++ b/src/nlpviewer/components/TextViewer.tsx
@@ -19,6 +19,8 @@ import {
 import LinkCreateBox from './LinkCreateBox';
 import AnnotationCreateBox from './AnnotationCreateBox';
 import groupPlugin from '../../plugins/group/Group';
+import {nextDocument, prevDocument} from '../../app/lib/api';
+import {useState} from 'react';
 
 export type OnEventType = (event: any) => void;
 
@@ -33,6 +35,9 @@ function TextViewer({ plugins, onEvent, layout }: TextViewerProp) {
 
   const appState = useTextViewerState();
   const dispatch = useTextViewerDispatch();
+
+  const [next_id, setNext] = useState<string>('');
+  const [prev_id, setPrev] = useState<string>('');
 
   const {
     textPack,
@@ -54,6 +59,15 @@ function TextViewer({ plugins, onEvent, layout }: TextViewerProp) {
   } = appState;
 
   if (!textPack || !ontology) return null;
+
+  let doc_id = window.location.pathname.split("/").pop() !;
+  nextDocument(doc_id).then(data => setNext(data.id));
+  prevDocument(doc_id).then(data => setPrev(data.id));
+  let next_url = '/documents/' + next_id;
+  let prev_url = '/documents/' + prev_id;
+
+
+  
 
   const { annotations, links, attributes } = textPack;
 
@@ -273,6 +287,27 @@ function TextViewer({ plugins, onEvent, layout }: TextViewerProp) {
               {annoEditIsCreating
                 ? `Cancel add annotation`
                 : `Add annotation`}
+            </button>
+            
+            {/* next and prev document */}
+            <button
+              className={style.add_prev_buttom}
+              onClick={() => {
+                window.location.href=prev_url;
+              }}
+            >
+              { `< Previous document`}
+            </button>
+            
+            
+
+            <button
+              className={style.add_next_buttom}
+              onClick={() => {
+                window.location.href=next_url;
+              }}
+            >
+              { `Next document >`}
             </button>
 
             {annoEditIsCreating && (

--- a/src/nlpviewer/components/TextViewer.tsx
+++ b/src/nlpviewer/components/TextViewer.tsx
@@ -63,11 +63,6 @@ function TextViewer({ plugins, onEvent, layout }: TextViewerProp) {
   let doc_id = window.location.pathname.split("/").pop() !;
   nextDocument(doc_id).then(data => setNext(data.id));
   prevDocument(doc_id).then(data => setPrev(data.id));
-  let next_url = '/documents/' + next_id;
-  let prev_url = '/documents/' + prev_id;
-
-
-  
 
   const { annotations, links, attributes } = textPack;
 
@@ -293,7 +288,12 @@ function TextViewer({ plugins, onEvent, layout }: TextViewerProp) {
             <button
               className={style.add_prev_buttom}
               onClick={() => {
-                window.location.href=prev_url;
+                if(doc_id !== prev_id){
+                  let prev_url = '/documents/' + prev_id;
+                  window.location.href=prev_url;
+                }else{
+                  alert('This is the first document of the project.')
+                }
               }}
             >
               { `< Previous document`}
@@ -304,7 +304,12 @@ function TextViewer({ plugins, onEvent, layout }: TextViewerProp) {
             <button
               className={style.add_next_buttom}
               onClick={() => {
-                window.location.href=next_url;
+                if(doc_id !== next_id){
+                  let next_url = '/documents/' + next_id;
+                  window.location.href=next_url;
+                }else{
+                  alert('This is the last document of the project.')
+                }
               }}
             >
               { `Next document >`}


### PR DESCRIPTION
This PR fixes [issue link]. 

### Description of changes
Add next document and previous document. If it's the first/last document, click on the button will direct you to the same document.

### Possible influences of this PR
No side -effects.

### Demonstration of results
Current implementation: next or previous document of a project **by document id in database**
![image](https://user-images.githubusercontent.com/38875181/94987763-53dd1680-059b-11eb-89e1-2383e9c1abe3.png)

P.S. I didn't find the drop upload box working, so there is still 1 document in each project. For test purpose, add the document manually to the database or simply move one document to the other project by changing the project id field in document.

