### PR TITLE
Add `is_shown` in the config to indicate whether an entry should be shown

### DIFF
--- a/src/app/pages/Projects.tsx
+++ b/src/app/pages/Projects.tsx
@@ -113,7 +113,7 @@ function Projects() {
         config['scopeConfigs'][entryName] = false;
       }
       
-      let legendConfig : ILegendConfig = {is_selected: false};
+      let legendConfig : ILegendConfig = {is_selected: false, is_shown: true};
       config['legendConfigs'][entryName] = legendConfig;
       if (entry.attributes && entry.attributes.length > 0) {
         let attributeConfig : ILegendAttributeConfig = {};

--- a/src/app/project_config.ts
+++ b/src/app/project_config.ts
@@ -2,32 +2,39 @@ import {IProjectConfigs} from '../nlpviewer'
 
 export const projectConfig: IProjectConfigs = {
   legendConfigs: {
-    "edu.cmu.TitleSpan": {is_selected: false},
-    "edu.cmu.BodySpan": {is_selected: false},
-    "edu.cmu.EventMention": {is_selected: true},
+    "edu.cmu.TitleSpan": {is_selected: false, is_shown: true},
+    "edu.cmu.BodySpan": {is_selected: false, is_shown: true},
+    "edu.cmu.EventMention": {is_selected: true, is_shown: true},
     "ft.onto.base_ontology.Token": {
       is_selected: false,
+      is_shown: true,
       attributes: {
         'pos': false,
       },
     },
     "ft.onto.base_ontology.EntityMention": {
-      is_selected: false        
+      is_selected: false,
+      is_shown: true,        
     },
     "ft.onto.base_ontology.EventMention": {
-      is_selected: true        
+      is_selected: true,
+      is_shown: true,        
     },
     "ft.onto.base_ontology.PredicateMention": {
-      is_selected: false        
+      is_selected: false,
+      is_shown: true,        
     },
     "ft.onto.base_ontology.PredicateArgument": {
-      is_selected: false        
+      is_selected: false,
+      is_shown: true,        
     },
     "ft.onto.base_ontology.PredicateLink": {
-      is_selected: false        
+      is_selected: false,
+      is_shown: true,        
     },
     "ft.onto.base_ontology.Dependency": {
-      is_selected: false        
+      is_selected: false,
+      is_shown: true,        
     }
   },
   scopeConfigs: {

--- a/src/nlpviewer/lib/interfaces.ts
+++ b/src/nlpviewer/lib/interfaces.ts
@@ -189,12 +189,13 @@ export interface ILayout {
   [position: string] : string;
 }
 
-export interface ILegendAttributeConfig{
+export interface ILegendAttributeConfig {
   [attribute: string]: boolean;
 }
 
-export interface ILegendConfig{
+export interface ILegendConfig {
   is_selected: boolean;
+  is_shown: boolean;
   attributes?: ILegendAttributeConfig;
 }
 

--- a/src/nlpviewer/lib/utils.ts
+++ b/src/nlpviewer/lib/utils.ts
@@ -381,7 +381,7 @@ export function isAvailableLegend(config: ILegendConfigs, entryName: string){
   if (Object.keys(config).length === 0){
     return true;
   }
-  return entryName in config;
+  return entryName in config && config[entryName]['is_shown'];
 }
 
 export function isEntryAnnotation(config: IOntology, entryName: string) {


### PR DESCRIPTION
This PR adds `is_shown` in the config to indicate whether an entry should be shown. #129  

### Description of changes
Instead of relying on whether an entry shows up in the config, this PR adds an `is_shown` field to indicate whether an entry should be shown. This makes it easier for the admin to toggle the visibility of an entry.

### Possible influences of this PR
n/a

### Demonstration of results
![image](https://user-images.githubusercontent.com/16990133/98759915-180a4d80-23a0-11eb-9db9-0095ef91356d.png)
![image](https://user-images.githubusercontent.com/16990133/98759934-235d7900-23a0-11eb-985f-99fb7795b6ae.png)

