### PR TITLE
Unify the project type names

### DIFF
--- a/simple-backend/nlpviewer_backend/handlers/project.py
+++ b/simple-backend/nlpviewer_backend/handlers/project.py
@@ -48,10 +48,9 @@ def create(request):
  
     received_json_data = json.loads(request.body)
 
-    project_type = received_json_data.get('type', 'indoc')
+    project_type = received_json_data.get('type', 'single_pack')
 
-    if project_type == 'indoc':
-
+    if project_type == 'single_pack':
         project = Project(
             project_type = project_type,
             name=received_json_data.get('name'),
@@ -59,7 +58,7 @@ def create(request):
             config=received_json_data.get('config'),
             user=request.user
         )
-    elif project_type == 'crossdoc':
+    elif project_type == 'multi_pack':
         project = Project(
             project_type = project_type,
             name=received_json_data.get('name'),

--- a/simple-backend/nlpviewer_backend/settings.py
+++ b/simple-backend/nlpviewer_backend/settings.py
@@ -15,6 +15,7 @@ import os
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
+DATA_UPLOAD_MAX_MEMORY_SIZE = 5242880
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/2.1/howto/deployment/checklist/

--- a/src/app/pages/Project.tsx
+++ b/src/app/pages/Project.tsx
@@ -45,7 +45,7 @@ function Docs() {
       return fetchDocumentsProject(project_id).then(docs => {
         setDocs(docs);
       });
-    } else if (info.project_type === 'crossdoc') {
+    } else if (info.project_type === 'multi_pack') {
       return fetchDocumentsAndMultiPacksProject(project_id).then(result => {
         setDocs(result.docs);
         setCrossDocs(result.crossdocs);
@@ -117,7 +117,7 @@ function Docs() {
         />
       </div>
 
-      {projectInfo && projectInfo.project_type === 'crossdoc'
+      {projectInfo && projectInfo.project_type === 'multi_pack'
         ? [
             <div className="content_left" style={{marginLeft: '20px'}}>
               <h2>All multi docs:</h2>

--- a/src/app/pages/Projects.tsx
+++ b/src/app/pages/Projects.tsx
@@ -44,7 +44,7 @@ const useStyles = makeStyles({
     marginBottom: 15,
   },
 });
-const PROJECT_TYPES = ['indoc', 'crossdoc'];
+const PROJECT_TYPES = ['single_pack', 'multi_pack'];
 
 function Projects() {
   const classes = useStyles();
@@ -57,7 +57,7 @@ function Projects() {
   const history = useHistory();
   const [open, setOpen] = React.useState(false);
 
-  const [projectType, setProjectType] = useState<string>('indoc');
+  const [projectType, setProjectType] = useState<string>('single_pack');
 
   const handleClickOpen = () => {
     setOpen(true);
@@ -87,12 +87,12 @@ function Projects() {
   }
 
   function handleAdd() {
-    if (projectType === 'indoc' && name && ontology !== '{}' && config) {
+    if (projectType === 'single_pack' && name && ontology !== '{}' && config) {
       createProject(projectType, name, ontology, config).then(() => {
         updateProjects();
       });
     } else if (
-      projectType === 'crossdoc' &&
+      projectType === 'multi_pack' &&
       name &&
       ontology !== '{}' &&
       multiOntology !== '{}' &&
@@ -250,11 +250,13 @@ function Projects() {
                         }
                       >
                         {PROJECT_TYPES.map(d => (
-                          <MenuItem value={d}>{d}</MenuItem>
+                          <MenuItem value={d} key={d}>
+                            {d}
+                          </MenuItem>
                         ))}
                       </Select>
                     </Grid>
-                    {projectType === 'indoc' ? (
+                    {projectType === 'single_pack' ? (
                       <div>
                         <div>
                           <TextField


### PR DESCRIPTION
This PR fixes https://github.com/asyml/stave/issues/154. 

### Description of changes
The project types used in different parts of the code are different, sometimes we have `indoc` and sometimes we have `single_pack`. This PR unify the project types to `single_pack`, to match this, the `crossdoc` name is renamed to `multi_pack`.

### Possible influences of this PR
Prior databases that are created with the project type `indoc` may be affected and will be not useful. People using the old database may need to change the project types (inside the database) accrodingly

### Demonstration of results
The project contents from the demo projects and newly added projects can be both displayed:

![Screen Shot 2021-02-23 at 11 38 18 PM](https://user-images.githubusercontent.com/1015991/108948355-56b2d380-7630-11eb-8806-dc2ed00f92d0.png)

![Screen Shot 2021-02-23 at 11 38 34 PM](https://user-images.githubusercontent.com/1015991/108948363-587c9700-7630-11eb-8f0e-765452eb164b.png)

