### PR TITLE
Update forte_examples to examples in nlp.py.

### DIFF
--- a/simple-backend/nlpviewer_backend/handlers/nlp.py
+++ b/simple-backend/nlpviewer_backend/handlers/nlp.py
@@ -45,12 +45,12 @@ def __load_eliza():
 def __load_utterance_searcher():
   if forte_installed:
     try:
-      from forte_examples.clinical_pipeline.utterance_searcher import LastUtteranceSearcher
+      from examples.clinical_pipeline.utterance_searcher import LastUtteranceSearcher
       from forte.data.readers import RawDataDeserializeReader
     except ImportError:
       logging.error(
         "Additional Forte examples: "
-        "https://github.com/asyml/forte/tree/master/forte_examples "
+        "https://github.com/asyml/forte/tree/master/examples "
         "needed to be installed to run this example.")
       return None
 


### PR DESCRIPTION
This PR fixes ImportError when loading `examples` in `nlp.py`. 

### Description of changes
`forte_examples` is outdates. Need to change the module name to `examples` and update the corresponding [GitHub link](https://github.com/asyml/forte/tree/master/examples).
