### PR TITLE
Add stave viewer mode

### DIFF
--- a/simple-backend/nlpviewer_backend/lib/stave_project.py
+++ b/simple-backend/nlpviewer_backend/lib/stave_project.py
@@ -1,0 +1,254 @@
+"""
+This module provides a set of interfaces to simplify the process of
+serializing/deserializing project between Stave database and local disk.
+
+StaveProjectWriter:
+    Serialize a Stave project to local disk storage.
+StaveProjectReader:
+    Parse a directory to get project information.
+"""
+
+import os
+import glob
+import json
+import errno
+import logging
+from typing import Union, Dict, Set, Any, List
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "StaveProjectReader"
+    "StaveProjectWriter"
+]
+
+
+class StaveProject:
+    """
+    Base class that defines the format of serialized project metadata.
+    It specifies the name (PROJECT_META_FILE) of file that stores the
+    metadata and the structure (****_FIELD) of json object.
+    It is extensible to support new structure/fields, which can be
+    registered in this class.
+    """
+
+    PROJECT_META_FILE = ".project_meta.json"
+    NAME_FIELD = "project_name"
+    TYPE_FIELD = "project_type"
+    ONTO_FIELD = "ontology"
+    CONF_FIELD = "project_configs"
+    MULT_FIELD = "multi_ontology"
+
+    def __init__(self, project_path: str):
+        """
+        Initialize base StaveProject.
+
+        Args:
+            project_path: Path to the project directory.
+        """
+        self._project_path: str = os.path.abspath(project_path)
+
+
+class StaveProjectReader(StaveProject):
+    """
+    Parse a pregenerated directory to get project information.
+    The project directory must exist and follow the standard
+    format specified below:
+
+        - project_path/
+            - PROJECT_META_FILE
+            - *.0.json
+            - *.1.json
+            - *.2.json
+            ...
+    
+    StaveProjectReader will extract project information from project
+    directory. Example usage:
+
+        project_reader = StaveProjectReader(project_path=project_path)
+        ontology = project_reader.ontology
+        project_configs = project_reader.project_configs
+        textpack_0 = project_reader.get_textpack(0)
+
+    """
+
+    def __init__(self, project_path: str):
+        """
+        Initialize StaveProjectReader and check the directory.
+        Verification on the project path is performed here, so make sure
+        to have the project direcotry correctly set and follow the standard
+        format.
+        
+        Args:
+            project_path: Path to the project directory.
+        """
+        super().__init__(project_path)
+
+        # Verify project path
+        if not os.path.isdir(self._project_path):
+            raise FileNotFoundError(
+                errno.ENOENT, os.strerror(errno.ENOENT), self._project_path)
+
+        # Load project meta data
+        with open(os.path.join(
+            self._project_path, self.PROJECT_META_FILE), "r") as f:
+            self._project_meta: Dict = json.load(f)
+
+    @property
+    def ontology(self):
+        return self._project_meta.get(self.ONTO_FIELD)
+
+    @property
+    def project_configs(self):
+        return self._project_meta.get(self.CONF_FIELD)
+
+    @property
+    def project_name(self):
+        return self._project_meta.get(self.NAME_FIELD)
+    
+    @property
+    def project_type(self):
+        return self._project_meta.get(self.TYPE_FIELD)
+    
+    @property
+    def multi_ontology(self):
+        return self._project_meta.get(self.MULT_FIELD)
+    
+    def get_textpack(self, index: int):
+        """
+        Get the target textpack based on input index. Will raise an exception
+        if the index is invalid or not found.
+
+        Args:
+            index: The index of target textpack.
+
+        Returns:
+            textpack: A dictionary representing a textpack.
+        """
+        with open(self.get_textpack_file(index), "r") as f:
+            textpack = json.load(f)
+        return textpack
+
+    def get_textpack_prefix(self, index: int):
+        textpack_file = os.path.basename(self.get_textpack_file(index))
+        return textpack_file[:-len(f".{index}.json")]
+
+    def get_textpack_file(self, index: int):
+        # TODO: The following implementation uses glob to find target 
+        #       textpack. It is easy for maintenance but can be less
+        #       efficient in some use cases. May find better way to track
+        #       files or may add a layer of caching in future version.
+        file_pattern = os.path.join(self._project_path, f"*.{index}.json")
+        match = glob.glob(file_pattern)
+        if len(match) != 1:
+            if len(match) == 0:
+                raise FileNotFoundError(
+                    errno.ENOENT, os.strerror(errno.ENOENT), file_pattern)
+            raise Exception("Duplicate textpack index.")
+        return match[0]
+
+    def get_next_index(self, index: int):
+        match = glob.glob(
+            os.path.join(self._project_path, f"*.{index + 1}.json"))
+        return index if len(match) == 0 else (index + 1)
+    
+    def get_prev_index(self, index: int):
+        return max(index - 1, 0)
+
+
+class StaveProjectWriter(StaveProject):
+    """
+    Serialize a Stave project onto local disk storage. It will follow the same
+    directory specification as StaveProjectReader:
+
+        - project_path/
+            - PROJECT_META_FILE
+            - *.0.json
+            - *.1.json
+            - *.2.json
+            ...
+
+    Any Stave project can be flushed to disk in the format above.
+    Example usage:
+
+        project_writer = StaveProjectWriter(
+            project_path=project_path,
+            project_name=project_name,
+            project_type=project_type,
+            ontology=ontology,
+            project_configs=project_configs
+        )
+        for textpack in textpack_list:
+            project_writer.write_textpack(textpack.name, textpack.content)
+
+    """
+
+    def __init__(self,
+        project_path: str,
+        project_name: str,
+        project_type: str,
+        ontology: Dict,
+        project_configs: Dict,
+        multi_ontology: Dict = {}
+    ):
+        """
+        Initialize StaveProjectWriter and create the project meta file.
+        If `project_path` does not exist, it will create a new directory.
+        
+        Args:
+            project_path: Path to the project directory.
+            project_name: Project name displayed on Stave.
+            project_type: single_pack / multi_pack.
+            ontology: A dictionary for project ontology.
+            project_configs: A dictionary for project configurations.
+            multi_ontology: A dictionary for multi_pack ontology.
+                Default to {}.
+        """
+        super().__init__(project_path)
+
+        if not os.path.isdir(self._project_path):
+            os.makedirs(self._project_path)
+
+        self._textpack_id: int = 0
+
+        # Create meta file
+        with open(os.path.join(
+            self._project_path,
+            self.PROJECT_META_FILE
+        ), "w") as f:
+            json.dump({
+                self.NAME_FIELD: project_name,
+                self.TYPE_FIELD: project_type,
+                self.ONTO_FIELD: ontology,
+                self.CONF_FIELD: project_configs,
+                self.MULT_FIELD: multi_ontology
+            }, f)
+
+        logger.info('Project["%s"] is saved under "%s".',
+            project_name, self._project_path)
+
+    def write_textpack(self, prefix: Union[int, str], textpack: str):
+        """
+        Write textpack to the project directory with standard naming scheme.
+        It returns the current textpack index to the caller.
+
+        Args:
+            prefix: A string (e.g., pack_name) or integer (e.g., pack_id) that
+                constructs the prefix of filename. The created file will be
+                named `{prefix}.{index}.json`. Note: Any `\` will be translated
+                into `_` in filename.
+            textpack: A string representing serialized DataPack.
+
+        Returns:
+            textpack_id: An index indicating sequential order of textpack.
+        """
+        textpack_id = self._textpack_id
+        prefix = str(prefix).replace('/', '_')
+
+        with open(os.path.join(
+            self._project_path,
+            f"{prefix}.{textpack_id}.json"
+        ), "w") as f:
+            f.write(textpack)
+            self._textpack_id += 1
+        return textpack_id

--- a/simple-backend/nlpviewer_backend/lib/stave_project.py
+++ b/simple-backend/nlpviewer_backend/lib/stave_project.py
@@ -95,26 +95,26 @@ class StaveProjectReader(StaveProject):
             self._project_meta: Dict = json.load(f)
 
     @property
-    def ontology(self):
+    def ontology(self) -> Dict:
         return self._project_meta.get(self.ONTO_FIELD)
 
     @property
-    def project_configs(self):
+    def project_configs(self) -> Union[Dict, None]:
         return self._project_meta.get(self.CONF_FIELD)
 
     @property
-    def project_name(self):
+    def project_name(self) -> str:
         return self._project_meta.get(self.NAME_FIELD)
     
     @property
-    def project_type(self):
+    def project_type(self) -> str:
         return self._project_meta.get(self.TYPE_FIELD)
     
     @property
-    def multi_ontology(self):
+    def multi_ontology(self) -> Dict:
         return self._project_meta.get(self.MULT_FIELD)
     
-    def get_textpack(self, index: int):
+    def get_textpack(self, index: int) -> Dict:
         """
         Get the target textpack based on input index. Will raise an exception
         if the index is invalid or not found.
@@ -129,11 +129,11 @@ class StaveProjectReader(StaveProject):
             textpack = json.load(f)
         return textpack
 
-    def get_textpack_prefix(self, index: int):
+    def get_textpack_prefix(self, index: int) -> str:
         textpack_file = os.path.basename(self.get_textpack_file(index))
         return textpack_file[:-len(f".{index}.json")]
 
-    def get_textpack_file(self, index: int):
+    def get_textpack_file(self, index: int) -> str:
         # TODO: The following implementation uses glob to find target 
         #       textpack. It is easy for maintenance but can be less
         #       efficient in some use cases. May find better way to track
@@ -147,12 +147,12 @@ class StaveProjectReader(StaveProject):
             raise Exception("Duplicate textpack index.")
         return match[0]
 
-    def get_next_index(self, index: int):
+    def get_next_index(self, index: int) -> int:
         match = glob.glob(
             os.path.join(self._project_path, f"*.{index + 1}.json"))
         return index if len(match) == 0 else (index + 1)
     
-    def get_prev_index(self, index: int):
+    def get_prev_index(self, index: int) -> int:
         return max(index - 1, 0)
 
 
@@ -188,7 +188,7 @@ class StaveProjectWriter(StaveProject):
         project_name: str,
         project_type: str,
         ontology: Dict,
-        project_configs: Dict,
+        project_configs: Union[Dict, None] = None,
         multi_ontology: Dict = {}
     ):
         """
@@ -201,6 +201,7 @@ class StaveProjectWriter(StaveProject):
             project_type: single_pack / multi_pack.
             ontology: A dictionary for project ontology.
             project_configs: A dictionary for project configurations.
+                Default to None.
             multi_ontology: A dictionary for multi_pack ontology.
                 Default to {}.
         """
@@ -227,7 +228,7 @@ class StaveProjectWriter(StaveProject):
         logger.info('Project["%s"] is saved under "%s".',
             project_name, self._project_path)
 
-    def write_textpack(self, prefix: Union[int, str], textpack: str):
+    def write_textpack(self, prefix: Union[int, str], textpack: str) -> int:
         """
         Write textpack to the project directory with standard naming scheme.
         It returns the current textpack index to the caller.

--- a/simple-backend/nlpviewer_backend/lib/stave_viewer.py
+++ b/simple-backend/nlpviewer_backend/lib/stave_viewer.py
@@ -113,9 +113,9 @@ class StaveViewer:
 
         def __init__(self, *args, **kwargs):
             super().__init__(*args, **kwargs)
-            self._project_reader: "StaveProjectReader"
+            self._project_reader: StaveProjectReader
 
-        def initialize(self, project_reader: "StaveProjectReader"):
+        def initialize(self, project_reader: StaveProjectReader):
             self._project_reader = project_reader
 
         def set_default_headers(self):

--- a/simple-backend/nlpviewer_backend/lib/stave_viewer.py
+++ b/simple-backend/nlpviewer_backend/lib/stave_viewer.py
@@ -1,0 +1,315 @@
+"""
+StaveViewer provides an interface to start Stave in viewer mode, which bypasses
+django backend APIs and databases to render visualization by rerouting data
+source to local disk storage system. This eliminates the need for users to
+worry about username, password, credentials, and permissions, so that it is
+simple and straightforward for users to boot up Stave for easy-visualization.
+
+Package Requirements:
+    tornado == 6.1
+    django == 3.2
+
+Environment:
+    PYTHONPATH: Absolute path (or relative path from PYTHONPATH)
+        to django backend folder should be inserted into PYTHONPATH.
+        Example: "stave/simple-backend/". Deprecated in future update.
+"""
+
+import os
+import sys
+import json
+import errno
+import logging
+import asyncio
+import threading
+import webbrowser
+from typing import Dict, Set, Any, List
+import requests
+
+import django
+from django.core.wsgi import get_wsgi_application
+
+from tornado.web import FallbackHandler, StaticFileHandler, \
+    RequestHandler, url, Application
+from tornado.httpserver import HTTPServer
+from tornado.ioloop import IOLoop
+from tornado.wsgi import WSGIContainer
+
+from .stave_project import StaveProjectReader
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "StaveViewer"
+]
+
+
+class StaveViewer:
+    """
+    StaveViewer allows users to start and control a Stave instance in viewer
+    mode. Example usage:
+
+        sv = StaveViewer(
+            build_path = os.path.join(stave_path, "build/")
+            project_path = project_path
+        )
+        sv.run()
+        sv.open()
+
+    The codes above initialize a StaveViewer instance by passing the Stave
+    build path(deprecated in future update) and project path. By calling
+    `run()`, StaveViewer starts a tornado server on a newly created thread.
+    `open()` method will open the browser with the visualization.
+    
+    Note: Currently the viewer mode is achieved by rerouting the django
+    backend requests and it can be hard to maintain when structure changes
+    in Stave. Refactoring is welcome to improve code logic and maintanence.
+    """
+
+    def __init__(self,
+        build_path: str,
+        project_path: str = '',
+        host: str = "localhost",
+        port: int = 8888,
+        thread_daemon: bool = False,
+        in_viewer_mode: bool = True
+    ):
+        """
+        Initialize StaveViewer with input paramaters.
+
+        Args:
+            build_path: Absolute path (or relative path from PYTHONPATH)
+                to stave build folder. Example: "stave/build/".
+            project_path: Path to the project directory for rendering.
+                Default to the current path ''.
+            host: host name for Stave server. Default value is `localhost`.
+            port: port number for Stave server. Default value is 8888.
+            thread_daemon: Set whether the thread is daemonic.
+                Default to False.
+            in_viewer_mode: Enable viewer mode of Stave. If False, StaveViewer
+                will start a standard Stave instance. Default to True.
+        """
+        self._project_reader: "StaveProjectReader"
+
+        self._project_path: str = project_path
+        self._build_path: str = build_path
+        
+        self._host: str = host
+        self._port: int = port
+        self._thread_daemon: bool = thread_daemon
+        
+        self.url: str = f"http://{host}:{port}"
+        self.server_started: bool = False
+        self.in_viewer_mode: bool = in_viewer_mode
+
+        # Used for sync between threads
+        self._barrier = threading.Barrier(2, timeout=1)
+
+    class ViewerHandler(RequestHandler):
+        """
+        Handler of Stave viewer requests.
+        Override django backend APIs to deal with requests from Stave Viewer.
+        """
+
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self._project_reader: "StaveProjectReader"
+
+        def initialize(self, project_reader: "StaveProjectReader"):
+            self._project_reader = project_reader
+
+        def set_default_headers(self):
+            self.set_header("Content-Type", 'application/json')
+
+    class PackOntoHandler(ViewerHandler):
+        """
+        Handler of requests `/api/ontology_from_doc/:id`.
+        Respond with a json object storing textPack and ontology.
+        """
+
+        def get(self, doc_id: str):
+            ontology = json.dumps(self._project_reader.ontology)
+            textpack = json.dumps(
+                        self._project_reader.get_textpack(int(doc_id)))
+            self.write({
+                "id": doc_id,
+                "textPack": textpack,
+                "ontology": ontology
+            })
+
+    class ConfigHandler(ViewerHandler):
+        """
+        Handler of requests `/api/config_from_doc/:id`.
+        Respond with a json object storing project configuration.
+        """
+
+        def get(self, doc_id: str):
+            self.write({
+                "id": doc_id,
+                "config": json.dumps(self._project_reader.project_configs)
+            })
+
+    class NextDocHandler(ViewerHandler):
+        """
+        Handler of requests `/api/next_doc/:id`.
+        Respond with a json object storing next document's id.
+        """
+
+        def get(self, doc_id: str):
+            self.write({
+                "id": self._project_reader.get_next_index(int(doc_id))
+            })
+
+    class PrevDocHandler(ViewerHandler):
+        """
+        Handler of requests `/api/prev_doc/:id`.
+        Respond with a json object storing previous document's id.
+        """
+
+        def get(self, doc_id: str):
+            self.write({
+                "id": self._project_reader.get_prev_index(int(doc_id))
+            })
+
+    class NonImplementHandler(ViewerHandler):
+        """
+        Handler of requests related to all the other django APIs.
+        Since editing in viewer mode is currently not allowed, these requests
+        will trigger an HTTP error (403 Forbidden).
+
+        TODO: In future update, if viewer mode editing is required,
+            these requests can be handled by reading/writing corresponding
+            textpack files.
+        """
+
+        def get(self):
+            self.send_error(403)
+
+        def post(self):
+            self.send_error(403)
+
+    class ProxyHandler(FallbackHandler):
+        """
+        URL routing for django web interface.
+        ProxyHandler directs all requests with `/api`-prefixed url to
+        the django wsgi application.
+        """
+
+        def initialize(self, fallback):
+            # Strip prefix "/api" from uri and path
+            # TODO: May look for more standard implementation in future.
+            self.request.uri = self.request.uri[4:]
+            self.request.path = self.request.path[4:]
+            super().initialize(fallback)
+
+    class ReactHandler(RequestHandler):
+        """
+        Handler of requests to React index page.
+        ReactHandler makes sure all requests fall back to index page
+        so that they can follow the standard React routing rules.
+        """
+
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self._build_path: str
+
+        def initialize(self, build_path):
+            self._build_path = build_path
+
+        def get(self):
+            self.render(self._build_path + "/index.html")
+
+    def run(self):
+        """
+        Create a new thread and start the Stave server.
+        """
+        if self.server_started:
+            return
+        
+        if self.in_viewer_mode:
+            self._project_reader = StaveProjectReader(
+                project_path=self._project_path
+            )
+
+        # Start a new thread to server Stave
+        thread = threading.Thread(
+            target=self._start_server,
+            daemon=self._thread_daemon
+        )
+        thread.start()
+
+        # Wait for server to boot up
+        self._barrier.wait()
+
+        if not thread.is_alive():
+            raise Exception("Stave server not started.")
+        self.server_started = True
+
+    def open(self, url=None):
+        """
+        Open browser for visualization.
+
+        Args:
+            url: Web browser will open the webpage directed by input url.
+                Default to None, which allows StaveViewer to automatically
+                set the url based on `in_viewer_mode`.
+        """
+        webbrowser.open(url or (
+            f"{self.url}/documents/0" if \
+            self.in_viewer_mode else self.url
+        ))
+
+    def _start_server(self):
+        asyncio.set_event_loop(asyncio.new_event_loop())
+        os.environ['DJANGO_SETTINGS_MODULE'] = "nlpviewer_backend.settings"
+        os.environ["DJANGO_ALLOW_ASYNC_UNSAFE"] = "true"
+        django.setup()
+
+        server = HTTPServer(self._get_application())
+        server.listen(self._port)
+
+        # Release lock in main thread
+        self._barrier.wait()
+
+        IOLoop.current().start()
+
+    def _get_application(self):
+        wsgi_app = WSGIContainer(get_wsgi_application())
+
+        # TODO: Find better logic to deal with routing.
+        #       The following implementation may miss some corner cases.
+        base_list = [
+            url(r'.*/static/(.*)', StaticFileHandler, {
+                "path": self._build_path + "/static/"
+            }),
+            url(r'.*/([^/]*\.png)', StaticFileHandler, {
+                "path": self._build_path
+            }),
+            url(r'.*/([^/]*\.ico)', StaticFileHandler, {
+                "path": self._build_path
+            }),
+            url(r"/.*", self.ReactHandler, {
+                "build_path": self._build_path
+            })
+        ]
+
+        if self.in_viewer_mode:
+            handler_args = {"project_reader": self._project_reader}
+            router_list = [
+                url(r"/api/ontology_from_doc/(.*)",
+                    self.PackOntoHandler, handler_args),
+                url(r"/api/config_from_doc/(.*)",
+                    self.ConfigHandler, handler_args),
+                url(r"/api/next_doc/(.*)",
+                    self.NextDocHandler, handler_args),
+                url(r"/api/prev_doc/(.*)",
+                    self.PrevDocHandler, handler_args),
+                url(r"/api/.*",
+                    self.NonImplementHandler, handler_args)
+            ]
+        else:
+            router_list = [
+                url(r"/api/(.*)", self.ProxyHandler, dict(fallback=wsgi_app))
+            ]
+
+        return Application(router_list + base_list)

--- a/simple-backend/nlpviewer_backend/lib/stave_viewer.py
+++ b/simple-backend/nlpviewer_backend/lib/stave_viewer.py
@@ -89,7 +89,7 @@ class StaveViewer:
             in_viewer_mode: Enable viewer mode of Stave. If False, StaveViewer
                 will start a standard Stave instance. Default to True.
         """
-        self._project_reader: "StaveProjectReader"
+        self._project_reader: StaveProjectReader
 
         self._project_path: str = project_path
         self._build_path: str = build_path


### PR DESCRIPTION
This PR fixes #173. 

### Description of changes
`stave_viewer` is introduced to provide an interface to start Stave in viewer mode, which bypasses django backend APIs and databases to render visualization by rerouting data source to local disk storage system. This eliminates the need for users to worry about username, password, credentials, and permissions, which makes it more simple and straightforward to boot up Stave for easy-visualization.
`stave_project` module provides a set of interfaces to simplify the process of serializing/deserializing project between Stave database and local disk.

### Possible influences of this PR
This PR adds two modules into Stave and does not affect other part of the code base. However, structural changes in Stave may deprecate some of the functionalities in these two modules.

### Demonstration of results
<img width="815" alt="image" src="https://user-images.githubusercontent.com/54747962/118201038-9796d900-b424-11eb-987a-d9fc0cd83008.png">
