### PR TITLE
Fix "shortId" Issue

### DIFF
--- a/simple-backend/nlpviewer_backend/handlers/nlp.py
+++ b/simple-backend/nlpviewer_backend/handlers/nlp.py
@@ -45,12 +45,12 @@ def __load_eliza():
 def __load_utterance_searcher():
   if forte_installed:
     try:
-      from forte_examples.clinical_pipeline.utterance_searcher import LastUtteranceSearcher
+      from examples.clinical_pipeline.utterance_searcher import LastUtteranceSearcher
       from forte.data.readers import RawDataDeserializeReader
     except ImportError:
       logging.error(
         "Additional Forte examples: "
-        "https://github.com/asyml/forte/tree/master/forte_examples "
+        "https://github.com/asyml/forte/tree/master/examples "
         "needed to be installed to run this example.")
       return None
 

--- a/src/nlpviewer/lib/utils.ts
+++ b/src/nlpviewer/lib/utils.ts
@@ -297,8 +297,8 @@ export function attributeId(legendId: string, attributeId: string) {
   return legendId + '_' + attributeId;
 }
 
-export function shortId(id: string) {
-  return id.replace('forte.data.ontology.', '');
+export function shortId(id: string | number) {
+  return id.toString().replace('forte.data.ontology.', '');
 }
 
 // export function checkAnnotationInGroup(


### PR DESCRIPTION
This PR fixes #177. 

### Description of changes
Add `toString()` after `id` to convert it to `string` before calling `replace()`.

### Possible influences of this PR
Update the type annotation of `id` to a union of `string` and `number`.

### Demonstration of results
Follow the same steps as described in #177.**ToReproduce** to see if the error is still there.
