### PR TITLE
Fix uuid precision loss

### DIFF
--- a/simple-backend/nlpviewer_backend/handlers/document.py
+++ b/simple-backend/nlpviewer_backend/handlers/document.py
@@ -468,10 +468,10 @@ def get_doc_ontology_pack(request, document_id):
     """
     doc = fetch_doc_check_perm(document_id, request.user, "nlpviewer_backend.read_project")
 
-    # Convert annotation uuids to string to prevent precision loss
-    textPackJson = json.loads(doc.textPack)
-    for annotation in textPackJson['py/state']['annotations']:
-        annotation['py/state']['_tid'] = str(annotation['py/state']['_tid'])
+    # Convert every large integer to string to prevent precision loss
+    # In javascript, integers are accurate up to 15 digits.
+    textPackJson = json.loads(doc.textPack,
+        parse_int=lambda si: int(si) if len(si) < 15 else si)
 
     docJson = {
         'id': document_id,

--- a/simple-backend/nlpviewer_backend/handlers/document.py
+++ b/simple-backend/nlpviewer_backend/handlers/document.py
@@ -242,7 +242,7 @@ def new_annotation(request, document_id):
     doc.textPack = json.dumps(textPackJson)
     doc.save()
 
-    return JsonResponse({"id": annotation_id}, safe=False)
+    return JsonResponse({"id": str(annotation_id)}, safe=False)
 
 @require_login
 def edit_annotation(request, document_id, annotation_id):
@@ -377,7 +377,7 @@ def new_link(request, document_id):
     doc.textPack = json.dumps(textPackJson)
     doc.save()
 
-    return JsonResponse({"id": link_id}, safe=False)
+    return JsonResponse({"id": str(link_id)}, safe=False)
 
 
 @require_login
@@ -468,9 +468,13 @@ def get_doc_ontology_pack(request, document_id):
     """
     doc = fetch_doc_check_perm(document_id, request.user, "nlpviewer_backend.read_project")
 
+    textPackJson = json.loads(doc.textPack)
+    for annotation in textPackJson['py/state']['annotations']:
+        annotation['py/state']['_tid'] = str(annotation['py/state']['_tid'])
+
     docJson = {
         'id': document_id,
-        'textPack': doc.textPack,
+        'textPack': json.dumps(textPackJson),
         'ontology': doc.project.ontology
     }
 

--- a/simple-backend/nlpviewer_backend/handlers/document.py
+++ b/simple-backend/nlpviewer_backend/handlers/document.py
@@ -468,6 +468,7 @@ def get_doc_ontology_pack(request, document_id):
     """
     doc = fetch_doc_check_perm(document_id, request.user, "nlpviewer_backend.read_project")
 
+    # Convert annotation uuids to string to prevent precision loss
     textPackJson = json.loads(doc.textPack)
     for annotation in textPackJson['py/state']['annotations']:
         annotation['py/state']['_tid'] = str(annotation['py/state']['_tid'])

--- a/simple-backend/nlpviewer_backend/handlers/nlp.py
+++ b/simple-backend/nlpviewer_backend/handlers/nlp.py
@@ -45,12 +45,12 @@ def __load_eliza():
 def __load_utterance_searcher():
   if forte_installed:
     try:
-      from forte_examples.clinical_pipeline.utterance_searcher import LastUtteranceSearcher
+      from examples.clinical_pipeline.utterance_searcher import LastUtteranceSearcher
       from forte.data.readers import RawDataDeserializeReader
     except ImportError:
       logging.error(
         "Additional Forte examples: "
-        "https://github.com/asyml/forte/tree/master/forte_examples "
+        "https://github.com/asyml/forte/tree/master/examples "
         "needed to be installed to run this example.")
       return None
 

--- a/src/nlpviewer/lib/utils.ts
+++ b/src/nlpviewer/lib/utils.ts
@@ -61,6 +61,9 @@ export function displayAttributeSidebar(attr_value: any) {
   if (attr_type === 'boolean') {
     return attr_value.toString();
   } else if (attr_type === 'string') {
+    // a temporary solution to show uuid
+    const parsed: number = parseInt(attr_value);
+    if (!isNaN(parsed)) return parsed.toString();
     return attr_value.substring(0, 3);
   } else if (attr_type === 'number') {
     return attr_value.toString();

--- a/src/nlpviewer/lib/utils.ts
+++ b/src/nlpviewer/lib/utils.ts
@@ -297,8 +297,8 @@ export function attributeId(legendId: string, attributeId: string) {
   return legendId + '_' + attributeId;
 }
 
-export function shortId(id: string) {
-  return id.replace('forte.data.ontology.', '');
+export function shortId(id: string | number) {
+  return id.toString().replace('forte.data.ontology.', '');
 }
 
 // export function checkAnnotationInGroup(


### PR DESCRIPTION
This PR fixes #181. 

### Description of changes
`JSON.parse()` in javascript may incur a precision loss when converting a large number like `uuid`, which leads to inconsistent `annotation_id` and `link_id` between frontend and backend. To solve this issue, we can convert `uuid` into `str` before passing to the frontend. 

### Possible influences of this PR
May slow down the API calls to `get_doc_ontology_pack` a little bit, because an additional step to convert every large integer into string is inserted before constructing a json response.

### Demonstration of results
Repeat the steps described in 
> #181.**To Reproduce**

and see if the annotation can be actually deleted after refreshing the webpage.
