### PR TITLE
Update stave CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ pip install stave
 ```
 #### Quick Start
  ```bash
-stave load -s
+stave start -l -o
 ```
-This will starts the Stave server with example project laoded. You can log in with default user name `admin` and default password `admin`. You can start viewing the projects and some annotations/applications that we have prepared.
+This will start the Stave server with example project loaded. `-l` will load example projects and `-o` will open a browser window. If you want to start Stave as a headless server, simply remove the `-o` flag. You can log in with default user name `admin` and default password `admin`. You can start viewing the projects and some annotations/applications that we have prepared.
 
 Or if you just want to start Stave from scratch, you can:
 
@@ -40,13 +40,24 @@ You can still log in with default user name `admin` and default password `admin`
 
 At any time, you can still load the example projects:
 ```bash
-stave load -s
+stave load
 ```
 
-The above command starts the server in a headless mode. You can start the server with browser too:
+#### Stave Configuration
+After you start the Stave server, a `.stave/` folder is automatically created under your home directory `~`. It has the following structure:
+```
+~/.stave/
+---- stave.conf
+---- db.sqlite3
+---- log
+```
+- `stave.conf` holds a json object of configurations.
+- `db.sqlite3` is the default database for Stave server.
+- `log` is the default logging file.
 
+You can view or update the configuration by running the subcommand `config`. For more information, refer to:
 ```bash
-stave -o start
+stave config -h
 ```
 
 #### More about the command line tool:

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ if sys.version_info < (3, 6):
 
 setuptools.setup(
     name="stave",
-    version="0.0.1.dev7",
+    version="0.0.1.dev8",
     url="https://github.com/asyml/stave",
 
     description="Stave is a fast, lightweight, extensible web-based text "

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ if sys.version_info < (3, 6):
 
 setuptools.setup(
     name="stave",
-    version="0.0.1.dev8",
+    version="0.0.1.dev9",
     url="https://github.com/asyml/stave",
 
     description="Stave is a fast, lightweight, extensible web-based text "

--- a/simple-backend/nlpviewer_backend/lib/stave_session.py
+++ b/simple-backend/nlpviewer_backend/lib/stave_session.py
@@ -90,7 +90,7 @@ class StaveSession(requests.Session):
         """
         Create a document in django database
         """
-        response = session.post(
+        response = self.post(
                         f"{self._url}/api/documents/new", json=document_json)
         if response.status_code != 200:
             raise Exception(f"create_document: Fail to create document.")

--- a/simple-backend/nlpviewer_backend/lib/stave_session.py
+++ b/simple-backend/nlpviewer_backend/lib/stave_session.py
@@ -67,6 +67,15 @@ class StaveSession(requests.Session):
             raise Exception("get_project_list: Fail to fetch project list.")
         return response
 
+    def get_document_list(self, project_id: int):
+        """
+        Fetch list of document in a project
+        """
+        response = self.get(f"{self._url}/api/projects/{project_id}/docs")
+        if response.status_code != 200:
+            raise Exception("get_document_list: Fail to fetch document list.")
+        return response
+
     def create_project(self, project_json):
         """
         Create a project in django database


### PR DESCRIPTION
This PR fixes #186. 

### Description of changes
- **stave_cli.py**:
    - `--open` and `--port-number` are moved from the global optional arguments to the subcommand `start` so that user can only start server with `stave start`.
    - `--load-samples` is moved from the `load` to `start`. Now simply run `stave load` to load sample projects into database without starting the server. If you want to start the server with sample projects, run `stave start -l`.
    - User can directly run `stave config` to view the current configuration.
- **README.md**
    - `Quick Start` is updated to reflect the CLI changes.
    - Add `Stave Configuration` part to explain the structure of `~/.stave/`.
- **stave_session.py**
    - Add interface for StaveProcessor in [#440](https://github.com/asyml/forte/pull/440). 

### Possible influences of this PR

### Demonstration of results
```bash
pip install stave==0.0.1.dev9
```
