### PR TITLE
Allow user specified django project

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -35,6 +35,8 @@ jobs:
           yarn install
           yarn run build
           mv ./build ./simple-backend/stave_backend/lib/build
+          rm ./simple-backend/stave_backend/settings.py
+          rm ./simple-backend/stave_backend/wsgi.py
       - name: Build a binary wheel and a source tarball
         run: |
           python -m build --sdist --wheel --outdir dist/ .

--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ pip install stave
 ```
 #### Quick Start
  ```bash
-stave start -l -o
+stave -s start -l -o
 ```
-This will start the Stave server with example project loaded. `-l` will load example projects and `-o` will open a browser window. If you want to start Stave as a headless server, simply remove the `-o` flag. You can log in with default user name `admin` and default password `admin`. You can start viewing the projects and some annotations/applications that we have prepared.
+This will start the Stave server with example project loaded. `-s` allows Stave to run with all the default configuration. `-l` will load example projects and `-o` will open a browser window. If you want to start Stave as a headless server, simply remove the `-o` flag. You can log in with default user name `admin` and default password `admin`. You can start viewing the projects and some annotations/applications that we have prepared.
 
 Or if you just want to start Stave from scratch, you can:
 
@@ -55,7 +55,12 @@ After you start the Stave server, a `.stave/` folder is automatically created un
 - `db.sqlite3` is the default database for Stave server.
 - `log` is the default logging file.
 
-You can view or update the configuration by running the subcommand `config`. For more information, refer to:
+You can view or update the configuration by running the subcommand `config`. 
+You may follow the prompts to interactively set up the configuration:
+```bash
+stave config -i
+```
+For more information, refer to:
 ```bash
 stave config -h
 ```

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ You can still log in with default user name `admin` and default password `admin`
 
 At any time, you can still load the example projects:
 ```bash
-stave load
+stave load-samples
 ```
 
 #### Stave Configuration

--- a/simple-backend/stave_backend/lib/stave_config.py
+++ b/simple-backend/stave_backend/lib/stave_config.py
@@ -1,0 +1,195 @@
+"""
+StaveConfig provides a basic interface to get/set configuration for Stave.
+"""
+
+import os
+import json
+import logging
+from enum import Enum
+from typing import Dict, Any, Iterator
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "StaveConfig"
+]
+
+
+class Fields(Enum):
+    DB_FILE = "db_file"
+    LOG_FILE = "log_file"
+    DJANGO_SETTINGS_MODULE = "django_settings_module"
+    SECRET_KEY = "_secret_key"
+    DJANGO_SETTINGS = "_django_settings"
+
+    @classmethod
+    def itervalue(cls) -> Iterator[str]:
+        return (field.value for field in cls)
+
+
+class StaveConfig:
+    """
+    A basic getter/setter interface for all public configurable
+    paramaters of Stave. Example usage:
+
+        sc = StaveConfig()
+        print(sc.db_file)
+        sc.log_file = "./log"
+
+    """
+
+    ADMIN_USERNAME = "admin"
+    ADMIN_PASSWORD = "admin"
+
+    CONFIG_PATH = os.path.join(os.path.expanduser('~'), ".stave")
+    CONFIG_FILE = os.path.join(CONFIG_PATH, "stave.conf")
+
+    DEFAULT_CONFIG_JSON = {
+        Fields.DJANGO_SETTINGS_MODULE.value: None,
+        Fields.DJANGO_SETTINGS.value: {
+            "ROOT_URLCONF": "stave_backend.urls",
+            "INSTALLED_APPS": [
+                'stave_backend',
+                'django.contrib.admin',
+                'django.contrib.auth',
+                'django.contrib.contenttypes',
+                'django.contrib.sessions',
+                'django.contrib.messages',
+                'django.contrib.staticfiles',
+                'guardian',
+            ],
+            "MIDDLEWARE": [
+                'django.middleware.security.SecurityMiddleware',
+                'django.contrib.sessions.middleware.SessionMiddleware',
+                'django.middleware.common.CommonMiddleware',
+                'django.contrib.auth.middleware.AuthenticationMiddleware',
+                'django.contrib.messages.middleware.MessageMiddleware',
+                'django.middleware.clickjacking.XFrameOptionsMiddleware',
+            ],
+            "DATABASES": {
+                'default': {
+                    'ENGINE': 'django.db.backends.sqlite3',
+                    'NAME': os.path.join(CONFIG_PATH, "db.sqlite3"),
+                }
+            },
+            "SECRET_KEY": None,
+            "ALLOWED_HOSTS": ["localhost"],
+            "LOGGING": {
+                'version': 1,
+                'disable_existing_loggers': False,
+                'formatters': {
+                    'verbose': {
+                        'format': '{levelname} {asctime} {module} {process:d} {thread:d} {message}',
+                        'style': '{',
+                    },
+                    'simple': {
+                        'format': '[{levelname}] {asctime} {module} {message}',
+                        'style': '{',
+                    },
+                },
+                'handlers': {
+                    'console': {
+                        'class': 'logging.StreamHandler',
+                        'formatter': 'simple',
+                    },
+                    'file': {
+                        'level': 'NOTSET',
+                        'class': 'logging.FileHandler',
+                        'filename': os.path.join(CONFIG_PATH, "log"),
+                        'formatter': 'verbose'
+                    },
+                },
+                'root': {
+                    'handlers': ['console', 'file'],
+                    'level': 'NOTSET',
+                },
+                'loggers': {
+                    'django': {
+                        'handlers': ['console', 'file'],
+                        'level': os.getenv('DJANGO_LOG_LEVEL', 'INFO'),
+                        'propagate': False,
+                    },
+                },
+            }
+        }
+    }
+
+    def __getattr__(self, name: str) -> Any:
+        if name not in Fields.itervalue():
+            return self.__getattribute__(name)
+
+        config: Dict[str, Any] = self._load_config()
+        if name == Fields.DB_FILE.value:
+            return config[
+                Fields.DJANGO_SETTINGS.value
+            ]["DATABASES"]["default"]["NAME"]
+        elif name == Fields.LOG_FILE.value:
+            return config[
+                Fields.DJANGO_SETTINGS.value
+            ]["LOGGING"]["handlers"]["file"]["filename"]
+        elif name == Fields.SECRET_KEY.value:
+            return config[Fields.DJANGO_SETTINGS.value]["SECRET_KEY"]
+        else:
+            return config.get(name)
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        if name not in Fields.itervalue():
+            return super().__setattr__(name, value)
+
+        config: Dict[str, Any] = self._load_config()
+        if name == Fields.DB_FILE.value:
+            config[
+                Fields.DJANGO_SETTINGS.value
+            ]["DATABASES"]["default"]["NAME"] = value
+        elif name == Fields.LOG_FILE.value:
+            config[
+                Fields.DJANGO_SETTINGS.value
+            ]["LOGGING"]["handlers"]["file"]["filename"] = value
+        elif name == Fields.SECRET_KEY.value:
+            config[Fields.DJANGO_SETTINGS.value]["SECRET_KEY"] = value
+        else:
+            config[name] = value
+
+        self._save_config(config)
+
+    @classmethod
+    def _save_config(cls, config: Dict[str, Any]):
+        if not os.path.isdir(cls.CONFIG_PATH):
+            os.mkdir(cls.CONFIG_PATH)
+        with open(cls.CONFIG_FILE, "w") as f:
+            json.dump(config, f)
+
+    @classmethod
+    def _load_config(cls) -> Dict[str, Any]:
+        """
+        Load or create configuration of Stave
+        """
+        if not os.path.isdir(cls.CONFIG_PATH):
+            os.mkdir(cls.CONFIG_PATH)
+
+        if not os.path.exists(cls.CONFIG_FILE):
+            with open(cls.CONFIG_FILE, "w") as f:
+                json.dump(cls.DEFAULT_CONFIG_JSON, f)
+
+        with open(cls.CONFIG_FILE, "r") as f:
+            return json.load(f)
+
+    @classmethod
+    def is_initialized(cls) -> bool:
+        if not os.path.isdir(cls.CONFIG_PATH):
+            return False
+        return os.path.exists(cls.CONFIG_FILE)
+
+    def show_config(self) -> None:
+        """
+        Show public configuration of Stave
+        """
+        print(json.dumps(
+            {
+                field: getattr(self, field)
+                for field in Fields.itervalue()
+                if not field.startswith('_')
+            },
+            sort_keys=True,
+            indent=4
+        ))

--- a/simple-backend/stave_backend/lib/stave_config.py
+++ b/simple-backend/stave_backend/lib/stave_config.py
@@ -16,6 +16,10 @@ __all__ = [
 
 
 class Fields(Enum):
+    """
+    Configurable fields of stave. Those do not start with '_' are treated
+    as public fields that can be showed and configured in CLI.
+    """
     DB_FILE = "db_file"
     LOG_FILE = "log_file"
     DJANGO_SETTINGS_MODULE = "django_settings_module"
@@ -29,8 +33,8 @@ class Fields(Enum):
 
 class StaveConfig:
     """
-    A basic getter/setter interface for all public configurable
-    paramaters of Stave. Example usage:
+    Provide basic getter/setter interfaces for all configurable paramaters
+    of Stave. Example usage:
 
         sc = StaveConfig()
         print(sc.db_file)
@@ -46,6 +50,8 @@ class StaveConfig:
 
     DEFAULT_CONFIG_JSON = {
         Fields.DJANGO_SETTINGS_MODULE.value: None,
+
+        # A basic django settings for Stave to run
         Fields.DJANGO_SETTINGS.value: {
             "ROOT_URLCONF": "stave_backend.urls",
             "INSTALLED_APPS": [
@@ -115,6 +121,10 @@ class StaveConfig:
     }
 
     def __getattr__(self, name: str) -> Any:
+        """
+        Getter for attributes in Fields. It will load from CONFIG_FILE and
+        route to the right config based on attribute name.
+        """
         if name not in Fields.itervalue():
             return self.__getattribute__(name)
 
@@ -133,6 +143,12 @@ class StaveConfig:
             return config.get(name)
 
     def __setattr__(self, name: str, value: Any) -> None:
+        """
+        Setter for attributes in Fields. It will load from CONFIG_FILE,
+        overwrite the corresponding config based on attribute name, and then
+        save it back to CONFIG_FILE. The access pattern of each config here
+        should be equivalent to "__getattr__".
+        """
         if name not in Fields.itervalue():
             return super().__setattr__(name, value)
 
@@ -154,6 +170,13 @@ class StaveConfig:
 
     @classmethod
     def _save_config(cls, config: Dict[str, Any]):
+        """
+        Save the configuration of Stave
+
+        Args:
+            config: A dict of Stave config. It should have the same format
+                with DEFAULT_CONFIG_JSON.
+        """
         if not os.path.isdir(cls.CONFIG_PATH):
             os.mkdir(cls.CONFIG_PATH)
         with open(cls.CONFIG_FILE, "w") as f:
@@ -176,6 +199,9 @@ class StaveConfig:
 
     @classmethod
     def is_initialized(cls) -> bool:
+        """
+        Check if the config file exists.
+        """
         if not os.path.isdir(cls.CONFIG_PATH):
             return False
         return os.path.exists(cls.CONFIG_FILE)

--- a/simple-backend/stave_backend/lib/stave_viewer.py
+++ b/simple-backend/stave_backend/lib/stave_viewer.py
@@ -272,7 +272,10 @@ class StaveViewer:
             load_samples: Indicate whether to load sample projects
                 into database. Deafult to False.
         """
-        if not os.path.exists(self._config.db_file):
+        if not os.path.exists(
+            settings.DATABASES.get("default", {}).get("NAME")
+            or self._config.db_file
+        ):
             call_command("migrate")
             User = get_user_model()
             User.objects.create_superuser(
@@ -313,7 +316,11 @@ class StaveViewer:
 
     def _init_django_project(self):
         """
-        Configure django project's settings.
+        Configure django project's settings. If "django_settings_module" is
+        set in StaveConfig, then we simply pass its value to the environment
+        variable "DJANGO_SETTINGS_MODULE" and django will automatically find
+        the settings (only if it's a valid path). Otherwise, we will use
+        "_django_settings" from StaveConfig to configure django.
         """
         config_module: Optional[str] = self._config.django_settings_module
         if config_module or os.environ.get("DJANGO_SETTINGS_MODULE"):


### PR DESCRIPTION
This PR fixes #206.

### Description of changes
1. **pypi.yml**
Remove `settings.py` and `wsgi.py` in stave package.
2. **READEME.md**
Update `stave load` to `stave load-samples`.
3. **stave_cli.py**
Add a new configurable argument `django_settings_module`.
Add interactive interface for user to set up and initialize config of stave.
4. **stave_config.py**
Define default configs.
Provide a set of interfaces to access/update stave configuration.
5. **stave_viewer.py**
Update the logic of configuring django.

### Possible influences of this PR
1. If an older version of stave was installed before, `~/.stave` needs to be removed to avoid potential conflicts (e.g., KeyError).
2. When users choose to set `django_settings_module`, they need to make sure the module is a path to a valid django project and `settings.py` is properly configured. Otherwise there may be undefined behaviors.
 

### Demonstration of results
1. Uninstall previous version of `stave` and remove the `~/.stave` folder:
```bash
rm -r ~/.stave
```
2. Install new version of stave_test
```bash
pip3 install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple stave_test
```
3. Run and try different stave commands as specified in `README.md`. You may either
(1) Skip all the initial configs to accept default django settings; or
(2) Set `django_settings_module` to a `settings.py` file from a properly configured `django` project. Refer to https://github.com/asyml/stave/blob/master/simple-backend/stave_backend/settings.py for more details.
